### PR TITLE
Only point dependabot to workspace root

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,41 +3,6 @@ version: 2
 updates:
 
 - package-ecosystem: cargo
-  directory: "/asylum"
-  schedule:
-    interval: daily
-    time: "21:00"
-  open-pull-requests-limit: 10
-
-- package-ecosystem: cargo
-  directory: "/cpparser"
-  schedule:
-    interval: daily
-    time: "22:00"
-  open-pull-requests-limit: 10
-
-- package-ecosystem: cargo
-  directory: "/clang-time-trace"
-  schedule:
-    interval: daily
-    time: "23:00"
-  open-pull-requests-limit: 10
-
-- package-ecosystem: cargo
-  directory: "/simpp"
-  schedule:
-    interval: daily
-    time: "01:00"
-  open-pull-requests-limit: 10
-
-- package-ecosystem: cargo
-  directory: "/cmakeperf"
-  schedule:
-    interval: daily
-    time: "02:00"
-  open-pull-requests-limit: 10
-
-- package-ecosystem: cargo
   directory: "/"
   schedule:
     interval: daily


### PR DESCRIPTION
According to https://github.com/dependabot/dependabot-core/issues/1207 , other workspace crates should be picked up automagically, and they do error out as currently set up...