### PR TITLE
Add support for "output" field in compilation database

### DIFF
--- a/cmakeperf/tests/measure/fixture.rs
+++ b/cmakeperf/tests/measure/fixture.rs
@@ -127,8 +127,12 @@ impl MeasurementTest {
 
         // Generate a compilation database entry running that command file
         let command = format!("{MOCK_EXE} {}", rel_cmd_path.display());
-        self.db
-            .push(DatabaseEntry::new(self.tmpdir.path(), command, input_path));
+        self.db.push(DatabaseEntry::new(
+            self.tmpdir.path(),
+            command,
+            input_path,
+            None,
+        ));
 
         // Record expected output in the compilation database
         self.output.insert(rel_input_path, resource_usage);


### PR DESCRIPTION
Newer versions of CMake add an "output" field to compilation database entries, with these versions we can now know the name of output files without parsing the compiler command line invocation.