### PR TITLE
Increase robustness to exotic clang versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,6 +93,9 @@ env_logger = "0.10"
 # Used for logging
 log = "0.4"
 
+# Used to parse versions
+regex = "1.10"
+
 # Used for logging in TUI mode
 syslog = "6.1"
 


### PR DESCRIPTION
As seen in #162, not all clang installations neatly follow the "clang version MAJOR.MINOR" template. This causes crofiler to fail when using, e.g., Debian's provided version of clang. This commit increases the robustness of the version checking by relying on a regular expression which can match a broader range of possible versions.

Resolves #162.